### PR TITLE
Fix Ed25519 encryption support using age tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ Or use the test command:
 
 Ed25519 is a signing algorithm (EdDSA), not an encryption algorithm. While OpenSSL can handle RSA encryption directly, Ed25519 keys cannot be used for asymmetric encryption. The `age` tool was specifically designed to work with SSH keys including Ed25519, providing a secure and modern encryption solution.
 
+### Automatic SSH Key Management
+
+If your SSH key is password-protected (recommended!), the askpass tool will:
+1. Automatically start ssh-agent if not running
+2. Check if your SSH key is loaded
+3. Prompt for your SSH key passphrase via GUI dialog if needed
+4. Load the key into ssh-agent for the session
+
+**Workflow:** You only enter your SSH key passphrase once per session (via GUI), then sudo commands only require the confirmation dialog. No terminal interaction needed!
+
 ## Commands
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -6,11 +6,16 @@ A secure askpass implementation using SSH key encryption for non-interactive sud
 
 1. Clone this repository
 2. Ensure you have SSH keys (supports ed25519, ecdsa, rsa, or dsa)
-3. Set the `SUDO_ASKPASS` environment variable in your shell configuration:
+3. **For Ed25519 keys**: Install the `age` encryption tool
+   - Arch Linux: `sudo pacman -S age`
+   - Ubuntu/Debian: `sudo apt install age`
+   - macOS: `brew install age`
+   - Or build from source: https://github.com/FiloSottile/age#installation
+4. Set the `SUDO_ASKPASS` environment variable in your shell configuration:
    ```bash
    export SUDO_ASKPASS="/path/to/secure-askpass/askpass"
    ```
-4. Store your sudo password:
+5. Store your sudo password:
    ```bash
    ./askpass-manager set
    ```
@@ -29,12 +34,20 @@ Or use the test command:
 
 ## Security
 
-- Passwords are encrypted with your SSH public key
+- Passwords are encrypted with your SSH keys using one of two methods:
+  - **Ed25519 keys**: Uses `age` encryption (requires age tool)
+  - **RSA/ECDSA/DSA keys**: Uses OpenSSL asymmetric encryption
 - Supports multiple SSH key types (ed25519, ecdsa, rsa, dsa) with automatic detection
 - Keys are checked in order of preference: ed25519 > ecdsa > rsa > dsa
-- Stored in `~/.sudo_askpass.ssh` with 600 permissions
+- Encrypted files stored with 600 permissions:
+  - Ed25519: `~/.sudo_askpass.age`
+  - RSA/ECDSA/DSA: `~/.sudo_askpass.ssh`
 - Falls back to system keyring if available
 - Refuses plain text storage
+
+### Why age for Ed25519?
+
+Ed25519 is a signing algorithm (EdDSA), not an encryption algorithm. While OpenSSL can handle RSA encryption directly, Ed25519 keys cannot be used for asymmetric encryption. The `age` tool was specifically designed to work with SSH keys including Ed25519, providing a secure and modern encryption solution.
 
 ## Commands
 

--- a/askpass
+++ b/askpass
@@ -38,6 +38,7 @@ except ImportError:
 SERVICE_NAME = "sudo-askpass"
 USERNAME = "sudo"
 SSH_ENCRYPTED_FILE = os.path.expanduser("~/.sudo_askpass.ssh")
+AGE_ENCRYPTED_FILE = os.path.expanduser("~/.sudo_askpass.age")
 CONFIG_FILE = os.path.expanduser("~/.config/secure-askpass/config.json")
 RATE_LIMIT_FILE = os.path.expanduser("~/.config/secure-askpass/rate_limit.json")
 AUDIT_LOG_FILE = os.path.expanduser("~/.config/secure-askpass/audit.log")
@@ -49,6 +50,16 @@ SSH_KEY_TYPES = [
     ("~/.ssh/id_rsa", "RSA"),
     ("~/.ssh/id_dsa", "DSA")
 ]
+
+def check_age_available():
+    """Check if age encryption tool is available"""
+    try:
+        result = subprocess.run(['age', '--version'], capture_output=True)
+        return result.returncode == 0
+    except FileNotFoundError:
+        return False
+
+HAS_AGE = check_age_available()
 
 def find_ssh_key():
     """Find the first available SSH private key"""
@@ -311,11 +322,35 @@ def check_security():
     
     return True
 
+def decrypt_with_age(encrypted_file):
+    """Decrypt data using age with SSH private key"""
+    if not HAS_AGE or not SSH_KEY or not os.path.exists(SSH_KEY):
+        return None
+
+    try:
+        with open(encrypted_file, 'rb') as f:
+            encrypted_data = f.read()
+
+        # Use age with SSH private key identity
+        result = subprocess.run(
+            ['age', '-d', '-i', SSH_KEY],
+            input=encrypted_data,
+            capture_output=True
+        )
+
+        if result.returncode == 0:
+            return result.stdout.decode('utf-8').strip()
+
+    except Exception:
+        pass
+
+    return None
+
 def decrypt_with_ssh_key(encrypted_file):
     """Decrypt data using SSH private key"""
     if not SSH_KEY or not os.path.exists(SSH_KEY):
         return None
-        
+
     try:
         with open(encrypted_file, 'rb') as f:
             encrypted_data = f.read()
@@ -449,8 +484,19 @@ def main():
         syslog.syslog(syslog.LOG_INFO, "Askpass called (process info unavailable)")
     
     password = None
-    
-    # Priority 1: SSH encrypted file
+
+    # Priority 1: Age encrypted file (for Ed25519 keys)
+    if os.path.exists(AGE_ENCRYPTED_FILE):
+        password = decrypt_with_age(AGE_ENCRYPTED_FILE)
+        if password:
+            print(password)
+            key_info = f" ({SSH_KEY_TYPE} key)" if SSH_KEY_TYPE else ""
+            syslog.syslog(syslog.LOG_INFO, f"Password retrieved via age encryption{key_info}")
+            # Clear password from memory
+            password = secure_memory_clear(password)
+            return
+
+    # Priority 2: SSH encrypted file (for RSA/ECDSA/DSA keys)
     if os.path.exists(SSH_ENCRYPTED_FILE):
         password = decrypt_with_ssh_key(SSH_ENCRYPTED_FILE)
         if password:
@@ -461,7 +507,7 @@ def main():
             password = secure_memory_clear(password)
             return
     
-    # Priority 2: Keyring
+    # Priority 3: Keyring
     if HAS_KEYRING and password is None:
         try:
             password = keyring.get_password(SERVICE_NAME, USERNAME)

--- a/askpass
+++ b/askpass
@@ -322,9 +322,115 @@ def check_security():
     
     return True
 
+def ensure_ssh_key_loaded():
+    """Ensure SSH key is loaded in ssh-agent, prompt for passphrase if needed"""
+    if not SSH_KEY or not os.path.exists(SSH_KEY):
+        return False
+
+    try:
+        # Check if ssh-agent is running
+        if not os.environ.get('SSH_AUTH_SOCK'):
+            # Start ssh-agent
+            result = subprocess.run(['ssh-agent', '-s'], capture_output=True, text=True)
+            if result.returncode == 0:
+                # Parse and set environment variables
+                for line in result.stdout.split('\n'):
+                    if '=' in line and 'echo' not in line:
+                        key, value = line.split(';')[0].split('=', 1)
+                        os.environ[key.strip()] = value.strip().strip('"').strip("'")
+
+        # Check if key is already loaded
+        check_result = subprocess.run(['ssh-add', '-l'], capture_output=True)
+        if check_result.returncode == 0:
+            # Check if our specific key is loaded
+            key_fingerprint = subprocess.run(
+                ['ssh-keygen', '-lf', SSH_KEY],
+                capture_output=True,
+                text=True
+            )
+            if key_fingerprint.returncode == 0:
+                fingerprint = key_fingerprint.stdout.split()[1]
+                if fingerprint in check_result.stdout.decode():
+                    return True
+
+        # Key not loaded, prompt for passphrase
+        passphrase = prompt_ssh_passphrase()
+        if not passphrase:
+            return False
+
+        # Add key to ssh-agent with passphrase
+        add_result = subprocess.run(
+            ['ssh-add', SSH_KEY],
+            input=passphrase.encode(),
+            capture_output=True
+        )
+
+        # Clear passphrase from memory
+        passphrase = None
+
+        return add_result.returncode == 0
+
+    except Exception as e:
+        syslog.syslog(syslog.LOG_ERR, f"Failed to ensure SSH key loaded: {e}")
+        return False
+
+def prompt_ssh_passphrase():
+    """Prompt for SSH key passphrase using GUI"""
+    # Try Tkinter first
+    if HAS_GUI and 'DISPLAY' in os.environ:
+        try:
+            import tkinter.simpledialog as simpledialog
+            root = tk.Tk()
+            root.withdraw()
+            root.attributes('-topmost', True)
+
+            passphrase = simpledialog.askstring(
+                "SSH Key Passphrase Required",
+                f"Enter passphrase for {SSH_KEY}:",
+                show='*'
+            )
+            root.destroy()
+            return passphrase
+        except Exception:
+            pass
+
+    # Try zenity
+    if 'DISPLAY' in os.environ:
+        try:
+            result = subprocess.run(
+                ['zenity', '--password', '--title=SSH Key Passphrase Required',
+                 f'--text=Enter passphrase for {SSH_KEY}:'],
+                capture_output=True,
+                text=True
+            )
+            if result.returncode == 0:
+                return result.stdout.strip()
+        except FileNotFoundError:
+            pass
+
+    # Try kdialog
+    if 'DISPLAY' in os.environ:
+        try:
+            result = subprocess.run(
+                ['kdialog', '--password', f'Enter passphrase for {SSH_KEY}:'],
+                capture_output=True,
+                text=True
+            )
+            if result.returncode == 0:
+                return result.stdout.strip()
+        except FileNotFoundError:
+            pass
+
+    return None
+
 def decrypt_with_age(encrypted_file):
     """Decrypt data using age with SSH private key"""
     if not HAS_AGE or not SSH_KEY or not os.path.exists(SSH_KEY):
+        return None
+
+    # Ensure SSH key is loaded in ssh-agent
+    if not ensure_ssh_key_loaded():
+        syslog.syslog(syslog.LOG_ERR, "Failed to load SSH key into ssh-agent")
         return None
 
     try:

--- a/askpass-manager
+++ b/askpass-manager
@@ -18,6 +18,7 @@ except ImportError:
 SERVICE_NAME = "sudo-askpass"
 USERNAME = "sudo"
 SSH_ENCRYPTED_FILE = os.path.expanduser("~/.sudo_askpass.ssh")
+AGE_ENCRYPTED_FILE = os.path.expanduser("~/.sudo_askpass.age")
 
 # SSH key types to try in order of preference
 SSH_KEY_TYPES = [
@@ -26,6 +27,16 @@ SSH_KEY_TYPES = [
     ("~/.ssh/id_rsa", "~/.ssh/id_rsa.pub", "RSA"),
     ("~/.ssh/id_dsa", "~/.ssh/id_dsa.pub", "DSA")
 ]
+
+def check_age_available():
+    """Check if age encryption tool is available"""
+    try:
+        result = subprocess.run(['age', '--version'], capture_output=True)
+        return result.returncode == 0
+    except FileNotFoundError:
+        return False
+
+HAS_AGE = check_age_available()
 
 def find_ssh_keypair():
     """Find the first available SSH keypair"""
@@ -38,11 +49,32 @@ def find_ssh_keypair():
 
 SSH_KEY, SSH_PUB, SSH_KEY_TYPE = find_ssh_keypair()
 
+def encrypt_with_age(password):
+    """Encrypt password with age using SSH public key"""
+    if not HAS_AGE or not SSH_PUB:
+        return None
+
+    try:
+        # Use age with SSH public key
+        result = subprocess.run(
+            ['age', '-R', SSH_PUB, '-a'],
+            input=password.encode(),
+            capture_output=True
+        )
+
+        if result.returncode == 0:
+            return result.stdout
+
+    except Exception:
+        pass
+
+    return None
+
 def extract_pubkey_for_openssl():
     """Convert SSH public key to OpenSSL format"""
     if not SSH_PUB:
         return None
-        
+
     try:
         # First extract the public key in PEM format
         result = subprocess.run(
@@ -50,7 +82,7 @@ def extract_pubkey_for_openssl():
             capture_output=True,
             text=True
         )
-        
+
         if result.returncode == 0:
             # Use secure temp file instead of predictable path
             import tempfile
@@ -60,10 +92,10 @@ def extract_pubkey_for_openssl():
             # Set restrictive permissions
             os.chmod(temp_pem, 0o600)
             return temp_pem
-        
+
     except Exception:
         pass
-    
+
     return None
 
 def encrypt_with_ssh_key(password):
@@ -187,20 +219,48 @@ def set_password():
     # Priority 1: Try SSH encryption
     if SSH_KEY and SSH_PUB:
         print(f"Using SSH key encryption ({SSH_KEY_TYPE} key)...")
-        encrypted = encrypt_with_ssh_key(password)
-        
-        if encrypted:
-            try:
-                with open(SSH_ENCRYPTED_FILE, 'wb') as f:
-                    f.write(encrypted)
-                os.chmod(SSH_ENCRYPTED_FILE, 0o600)
-                print(f"Password encrypted with {SSH_KEY_TYPE} key and stored in {SSH_ENCRYPTED_FILE}")
-                # Clear sensitive data from memory
-                secure_clear(password)
-                secure_clear(confirm)
-                return True
-            except Exception as e:
-                print(f"Error saving SSH encrypted file: {e}")
+
+        # For Ed25519 keys, use age if available
+        if SSH_KEY_TYPE == "Ed25519" and HAS_AGE:
+            print("Using age encryption for Ed25519 key...")
+            encrypted = encrypt_with_age(password)
+
+            if encrypted:
+                try:
+                    with open(AGE_ENCRYPTED_FILE, 'wb') as f:
+                        f.write(encrypted)
+                    os.chmod(AGE_ENCRYPTED_FILE, 0o600)
+                    print(f"Password encrypted with {SSH_KEY_TYPE} key and stored in {AGE_ENCRYPTED_FILE}")
+                    # Clear sensitive data from memory
+                    secure_clear(password)
+                    secure_clear(confirm)
+                    return True
+                except Exception as e:
+                    print(f"Error saving age encrypted file: {e}")
+
+        # For Ed25519 without age, show helpful error
+        elif SSH_KEY_TYPE == "Ed25519" and not HAS_AGE:
+            print("Error: Ed25519 keys require the 'age' encryption tool", file=sys.stderr)
+            print("Install age: https://github.com/FiloSottile/age#installation", file=sys.stderr)
+            print("Or generate an RSA key: ssh-keygen -t rsa -b 4096", file=sys.stderr)
+            return False
+
+        # For RSA/ECDSA/DSA, use OpenSSL
+        else:
+            encrypted = encrypt_with_ssh_key(password)
+
+            if encrypted:
+                try:
+                    with open(SSH_ENCRYPTED_FILE, 'wb') as f:
+                        f.write(encrypted)
+                    os.chmod(SSH_ENCRYPTED_FILE, 0o600)
+                    print(f"Password encrypted with {SSH_KEY_TYPE} key and stored in {SSH_ENCRYPTED_FILE}")
+                    # Clear sensitive data from memory
+                    secure_clear(password)
+                    secure_clear(confirm)
+                    return True
+                except Exception as e:
+                    print(f"Error saving SSH encrypted file: {e}")
     else:
         print("SSH keys not found, trying other methods...")
     
@@ -222,11 +282,16 @@ def set_password():
 
 def get_password():
     """Check for stored password in priority order"""
+    # Check age encrypted file
+    if os.path.exists(AGE_ENCRYPTED_FILE):
+        print("Password found (age encrypted with SSH key)")
+        return True
+
     # Check SSH encrypted file
     if os.path.exists(SSH_ENCRYPTED_FILE):
         print("Password found (SSH encrypted)")
         return True
-    
+
     # Check keyring
     if HAS_KEYRING:
         try:
@@ -236,14 +301,23 @@ def get_password():
                 return True
         except Exception:
             pass
-    
+
     print("No password found")
     return False
 
 def clear_password():
     """Clear all stored passwords"""
     cleared = False
-    
+
+    # Clear age encrypted file
+    if os.path.exists(AGE_ENCRYPTED_FILE):
+        try:
+            os.remove(AGE_ENCRYPTED_FILE)
+            print("Age encrypted password cleared")
+            cleared = True
+        except Exception as e:
+            print(f"Error clearing age encrypted file: {e}")
+
     # Clear SSH encrypted file
     if os.path.exists(SSH_ENCRYPTED_FILE):
         try:


### PR DESCRIPTION
Ed25519 is a signing algorithm (EdDSA), not an encryption algorithm. The previous implementation attempted to use ssh-keygen -e -m PKCS8 which fails for Ed25519 keys because they cannot be converted to PKCS8 format for OpenSSL asymmetric encryption.

Changes:
- Add age encryption tool support for Ed25519 keys
- Age natively supports SSH keys including Ed25519
- Keep OpenSSL encryption for RSA/ECDSA/DSA keys (backward compatible)
- Add clear error message if age is not installed for Ed25519 users
- Update askpass script to decrypt age-encrypted files
- Store Ed25519 encrypted passwords in ~/.sudo_askpass.age
- Store RSA/ECDSA/DSA encrypted passwords in ~/.sudo_askpass.ssh
- Update documentation with installation instructions for age
- Add explanation of why age is needed for Ed25519

Testing:
- Verified encryption works with Ed25519 keys when age is installed
- Verified clear error message when age is missing
- Backward compatible with existing RSA key setups

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)